### PR TITLE
Fix env specification link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # env
 
-[Specification for .env](.env)
+[Specification for .env](env.md)
 
 ## Objectives
 


### PR DESCRIPTION
I noticed the link to the `env.md` specification file was invalid due to the leading `.` and missing file extension.

Thought I'd submit a quick PR to fix it.

Thanks!